### PR TITLE
Fix for issue #260

### DIFF
--- a/js/jquery.anythingslider.js
+++ b/js/jquery.anythingslider.js
@@ -646,8 +646,8 @@
 			}
 			if (o.buildArrows && o.toggleArrows) {
 				if (!base.hovered && base.playing) { sign = 1; op = 0; } // don't animate arrows during slideshow
-				base.$forward.stop(true,true).delay(t1).animate({ right: base.$forwardRight + ( sign ? base.$arrowWidth : 0 ), opacity: op }, o.animationTime/2);
-				base.$back.stop(true,true).delay(t1).animate({ left: base.$backLeft + ( sign ? base.$arrowWidth : 0 ), opacity: op }, o.animationTime/2);
+				base.$forward.stop(true,true).delay(t1).animate({ right: base.$forwardRight + (sign ? base.$arrowWidth : 0), opacity: op }, o.animationTime/2);
+				base.$back.stop(true,true).delay(t1).animate({ left: base.$backLeft + (sign ? base.$arrowWidth : 0), opacity: op }, o.animationTime/2);
 			}
 		};
 


### PR DESCRIPTION
Fix issue #260: Instead of animating from and to position 0 and (arrowWidth). Animate to and from (originalValue) to (originalValue) + (arrowWidth). Shouldn't change anything for the default theme (width === 0+width), but fixes it for themes as described in issue #260
