### PR TITLE
Bugfixes for hash tags

### DIFF
--- a/js/jquery.anythingslider.js
+++ b/js/jquery.anythingslider.js
@@ -265,7 +265,6 @@
 							// prevent running functions twice (once for click, second time for focusin)
 							base.flag = true; setTimeout(function(){ base.flag = false; }, 100);
 							base.gotoPage(index);
-							if (o.hashTags) { base.setHash(index); }
 						}
 						e.preventDefault();
 					})
@@ -549,7 +548,7 @@
 			base.$items.removeClass('activePage').eq(page - base.adj).addClass('activePage');
 
 			if (!base.hovered) { base.slideControls(false); }
-
+            if (o.hashTags) { base.setHash(page); }
 			if (time >= 0) { base.$el.trigger('slide_complete', base); }
 			// callback from external slide control: $('#slider').anythingSlider(4, function(slider){ })
 			if (typeof callback === 'function') { callback(base); }


### PR DESCRIPTION
Fixed not sliding when clicking pagination buttons
Fixed not changing hash when clicking forward / backward button

The hash tags will now be changed after the slide animation is finished, instead of when clicking on a pagination button. This is also was prohibited the slide animation from showing when clicking on those buttons.
Also, the hash tag will be changed when clicking on the arrow buttons.

I did not build a minified version for that.
