### PR TITLE
Add anchors for easier external linking

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,6 +247,7 @@
 
 		<br>
 
+    <a name="features"></a>
 		<h2>Features</h2>
 		<ul>
 			<li>Panels are HTML Content (can be anything).</li>
@@ -272,6 +273,7 @@
 			<li>Works with jQuery 1.4.2+.</li>
 		</ul>
 
+    <a name="default-options"></a>
 		<h2>Default Options</h2>
 		See the documentation for complete description of these options (<a href="https://github.com/ProLoser/AnythingSlider/wiki/Appearance-Options">appearance</a>, <a href="https://github.com/ProLoser/AnythingSlider/wiki/Navigation-Options">navigation</a>, <a href="https://github.com/ProLoser/AnythingSlider/wiki/Slideshow-Options">slideshow</a>, <a href="https://github.com/ProLoser/AnythingSlider/wiki/Callbacks-and-Events">callbacks &amp; events</a>, <a href="https://github.com/ProLoser/AnythingSlider/wiki/Video">video</a>, <a href="https://github.com/ProLoser/AnythingSlider/wiki/Interactivity-and-Miscellaneous-Options">interativity &amp; misc</a>).<br>
 		<br>
@@ -358,11 +360,13 @@
 });</pre>
 		</blockquote>
 
+    <a name="known-issues"></a>
 		<h2>Known Issues</h2>
 		<ul>
 			<li>Please refer to the <a href="https://github.com/ProLoser/AnythingSlider/wiki">documentation</a>.</li>
 		</ul>
 
+    <a name="changelog"></a>
 		<h2>Changelog</h2>
 
 		Only the latest versions will be shown here. See the <a href="https://github.com/ProLoser/AnythingSlider/wiki/Change-Log">full change log here</a>.<br>


### PR DESCRIPTION
I wanted to link the "default options" section in our code, but found there was no anchor.  I added an anchor for each `<h2>` element in this pull request.

An example of how it would be used: http://proloser.github.com/AnythingSlider/#default-options

Nice and simple.  :smile:
